### PR TITLE
[RUBY] Migrate from Authy to Verify for SMS 2FA

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,7 @@
-AUTHY_ID=123456
-AUTHY_API_KEY=d57d919d11e6b221c9bf6f7c882028f9
+# Find these credentials in the Twilio Console: https://www.twilio.com/console
+export TWILIO_ACCOUNT_SID="ACxxx"
+export TWILIO_AUTH_TOKEN="123xxx"
+
+
+# Create a Verify Service in the Console: https://www.twilio.com/console/verify/services
+export VERIFY_SERVICE_SID="VAxxx"

--- a/ruby.rb
+++ b/ruby.rb
@@ -1,25 +1,26 @@
-# Download the helper library from https://github.com/twilio/authy-ruby
-require 'authy'
+# Download the helper library from https://www.twilio.com/docs/ruby/install
+require 'rubygems'
+require 'twilio-ruby'
 
-# Your API key from twilio.com/console/authy/applications
-# DANGER! This is insecure. See http://twil.io/secure
-Authy.api_key = ENV['AUTHY_API_KEY']
-Authy.api_uri = 'https://api.authy.com'
+# Your Account Sid and Auth Token from twilio.com/console
+# and set the environment variables. See http://twil.io/secure
+account_sid = ENV['TWILIO_ACCOUNT_SID']
+auth_token = ENV['TWILIO_AUTH_TOKEN']
+@client = Twilio::REST::Client.new(account_sid, auth_token)
 
 
 def send
-    verification = Authy::API.request_sms(:id => ENV['AUTHY_ID'])
+    # Create a Verify Service in the Console: https://www.twilio.com/console/verify/services
+    verify_service_sid = ENV['VERIFY_SERVICE_SID']
 
-    puts verification.message
-end
+    # Use this instead of the Authy ID.
+    # Must be in E.164 format: https://www.twilio.com/docs/glossary/what-e164
+    to_number = '+15017122661'
 
+    verification = @client.verify
+                        .services(verify_service_sid)
+                        .verifications
+                        .create(to: to_number, channel: 'sms')
 
-def check(token)
-    response = Authy::API.verify(:id => authy_id, :token => token)
-
-    if response.ok?
-        # correct token
-    else
-        # incorrect token
-    end
+    puts verification.sid
 end

--- a/ruby.rb
+++ b/ruby.rb
@@ -8,19 +8,33 @@ account_sid = ENV['TWILIO_ACCOUNT_SID']
 auth_token = ENV['TWILIO_AUTH_TOKEN']
 @client = Twilio::REST::Client.new(account_sid, auth_token)
 
+# Create a Verify Service in the Console: https://www.twilio.com/console/verify/services
+verify_service_sid = ENV['VERIFY_SERVICE_SID']
+
+# Use this instead of the Authy ID.
+# Must be in E.164 format: https://www.twilio.com/docs/glossary/what-e164
+to_number = '+15017122661'
+
 
 def send
-    # Create a Verify Service in the Console: https://www.twilio.com/console/verify/services
-    verify_service_sid = ENV['VERIFY_SERVICE_SID']
-
-    # Use this instead of the Authy ID.
-    # Must be in E.164 format: https://www.twilio.com/docs/glossary/what-e164
-    to_number = '+15017122661'
-
     verification = @client.verify
-                        .services(verify_service_sid)
-                        .verifications
-                        .create(to: to_number, channel: 'sms')
+        .services(verify_service_sid)
+        .verifications
+        .create(to: to_number, channel: 'sms')
 
     puts verification.sid
+end
+
+
+def check(token)
+    verification_check = @client.verify
+        .services(verify_service_sid)
+        .verification_checks
+        .create(to: to_number, code: token)
+
+    if verification_check.status == "approved"
+        # correct token
+    else
+        # incorrect token
+    end
 end


### PR DESCRIPTION
Here's what you'll need to change:

1. Instead of the Authy Ruby library, use the [Twilio Ruby library](https://www.twilio.com/docs/ruby/install).
2. Instead of Authy API Keys, you'll need your [Twilio Account SID and Auth Token](https://www.twilio.com/console). 
3. You'll also need to create a [Verify Service and grab the SID](https://www.twilio.com/console/verify/services).
4. Finally, instead of the Authy ID, use the [phone number in E.164 format](https://www.twilio.com/docs/glossary/what-e164).

[Docs](https://www.twilio.com/docs/verify/api/verification?code-sample=code-start-a-verification-with-sms&code-language=Ruby&code-sdk-version=5.x)

To send a verification for the voice channel, all you need to do is change the `channel` to `call`.