### PR TITLE
[PYTHON] Migrate from Authy to Verify for SMS 2FA

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,7 @@
-AUTHY_ID=123456
-AUTHY_API_KEY=d57d919d11e6b221c9bf6f7c882028f9
+# Find these credentials in the Twilio Console: https://www.twilio.com/console
+export TWILIO_ACCOUNT_SID="ACxxx"
+export TWILIO_AUTH_TOKEN="123xxx"
+
+
+# Create a Verify Service in the Console: https://www.twilio.com/console/verify/services
+export VERIFY_SERVICE_SID="VAxxx"

--- a/python.py
+++ b/python.py
@@ -1,20 +1,42 @@
-# Download the helper library from https://github.com/twilio/authy-python
-from authy.api import AuthyApiClient
+# Download the helper library from https://www.twilio.com/docs/python/install
+from twilio.rest import Client
+from twilio.base.exceptions import TwilioRestException
 import os
 
-authy_id = os.environ["AUTHY_ID"]
-api_key = os.environ["AUTHY_API_KEY"]
-client = AuthyApiClient(api_key)
+# Find these credentials in the Twilio Console: https://www.twilio.com/console
+account_sid = os.environ['TWILIO_ACCOUNT_SID']
+auth_token = os.environ['TWILIO_AUTH_TOKEN']
+client = Client(account_sid, auth_token)
+
+# Create a Verify Service in the Console: https://www.twilio.com/console/verify/services
+verify_service_sid = os.environ['VERIFY_SERVICE_SID']
+
+# Use this instead of the Authy ID.
+# Must be in E.164 format: https://www.twilio.com/docs/glossary/what-e164
+to_number = '+15017122661'
 
 def send():
-    verification = client.users.request_sms(authy_id)
+    try:
+        verification = client.verify \
+            .services(verify_service_sid) \
+            .verifications \
+            .create(to=to_number, channel='sms')
 
-    if verification.ok():
-        print(verification.content)
-    else:
-        print(verification.errors())
+        print(verification.sid)
+    except TwilioRestException as e:
+        print(e)
 
 
 def check(token):
-    verification = authy_api.tokens.verify(authy_id, token=token)
-    print(verification.ok())
+    try:
+        verification_check = client.verify \
+            .services(verify_service_sid) \
+            .verification_checks \
+            .create(to=to_number, code=token)
+
+        if verification_check.status == "approved":
+            # valid token
+        else:
+            # invalid token
+    except TwilioRestException as e:
+        print(e)


### PR DESCRIPTION
Here's what you'll need to change:

1. Instead of the Authy Python library, use the [Twilio Python library](https://www.twilio.com/docs/python/install).
2. Instead of Authy API Keys, you'll need your [Twilio Account SID and Auth Token](https://www.twilio.com/console). 
3. You'll also need to create a [Verify Service and grab the SID](https://www.twilio.com/console/verify/services).
4. Finally, instead of the Authy ID, use the [phone number in E.164 format](https://www.twilio.com/docs/glossary/what-e164).

[Docs](https://www.twilio.com/docs/verify/api/verification?code-sample=code-start-a-verification-with-voice&code-language=Python&code-sdk-version=6.x)

To send a verification for the voice channel, all you need to do is change the `channel` to `call`.

**Note**: the Twilio Python helper library will throw exceptions for invalid requests so we recommend wrapping calls inside of a `try` block.