### PR TITLE
[PHP] Migrate from Authy to Verify for SMS 2FA

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,7 @@
-AUTHY_ID=123456
-AUTHY_API_KEY=d57d919d11e6b221c9bf6f7c882028f9
+# Find these credentials in the Twilio Console: https://www.twilio.com/console
+export TWILIO_ACCOUNT_SID="ACxxx"
+export TWILIO_AUTH_TOKEN="123xxx"
+
+
+# Create a Verify Service in the Console: https://www.twilio.com/console/verify/services
+export VERIFY_SERVICE_SID="VAxxx"

--- a/php.php
+++ b/php.php
@@ -5,22 +5,34 @@
 // see https://getcomposer.org/doc/01-basic-usage.md
 require_once '/path/to/vendor/autoload.php';
 
-$authy_api = new Authy\AuthyApi(getenv('AUTHY_API_KEY'));
+// Find your Account Sid and Auth Token at twilio.com/console
+// and set the environment variables. See http://twil.io/secure
+$sid = getenv("TWILIO_ACCOUNT_SID");
+$token = getenv("TWILIO_AUTH_TOKEN");
+$twilio = new Client($sid, $token);
+
+# Create a Verify Service in the Console: https://www.twilio.com/console/verify/services
+$verify_service_sid = getenv("VERIFY_SERVICE_SID");
+
+# Use this instead of the Authy ID.
+# Must be in E.164 format: https://www.twilio.com/docs/glossary/what-e164
+$to_number = "+15017122661";
+
 
 function send() {
-    $sms = $authy_api->requestSms(getenv('AUTHY_ID'));
+    $verification = $twilio->verify->v2->services($verify_service_sid)
+                                   ->verifications
+                                   ->create($to_number, "sms");
 
-    if ($sms->ok()) {
-        printf($sms->message());
-    } else {
-        print_r($sms->errors());
+    if ($verification->status == "pending") {
+        print($verification->sid);
     }
 }
 
 function check($token) {
-    $verification = $authy_api->verifyToken($authy_id, $token);
-
-    if ($verification->ok()) {
-        // correct token
-    }
+    $verification_check = $twilio->verify->v2->services("VAXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX")
+                                         ->verificationChecks
+                                         ->create($token,
+                                                  ["to" => $to_number]
+                                         );
 }

--- a/php.php
+++ b/php.php
@@ -18,7 +18,6 @@ $verify_service_sid = getenv("VERIFY_SERVICE_SID");
 # Must be in E.164 format: https://www.twilio.com/docs/glossary/what-e164
 $to_number = "+15017122661";
 
-
 function send() {
     $verification = $twilio->verify->v2->services($verify_service_sid)
                                    ->verifications
@@ -30,9 +29,9 @@ function send() {
 }
 
 function check($token) {
-    $verification_check = $twilio->verify->v2->services("VAXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX")
+    $verification_check = $twilio->verify->v2->services($verify_service_sid)
                                          ->verificationChecks
-                                         ->create($token,
-                                                  ["to" => $to_number]
-                                         );
+                                         ->create($token, ["to" => $to_number]);
+    
+    print($verification_check->status);
 }


### PR DESCRIPTION
Here's what you'll need to change:

1. Instead of the Authy PHP library, use the [Twilio PHP library](https://www.twilio.com/docs/libraries/php).
2. Instead of Authy API Keys, you'll need your [Twilio Account SID and Auth Token](https://www.twilio.com/console). 
3. You'll also need to create a [Verify Service and grab the SID](https://www.twilio.com/console/verify/services).
4. Finally, instead of the Authy ID, use the [phone number in E.164 format](https://www.twilio.com/docs/glossary/what-e164).

[Docs](https://www.twilio.com/docs/verify/api/verification?code-sample=code-start-a-verification-with-sms&code-language=PHP&code-sdk-version=6.x)

To send a verification for the voice channel, all you need to do is change the `channel` to `call`.