### PR TITLE
[CURL] Migrate from Authy to Verify for SMS 2FA

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,7 @@
-AUTHY_ID=123456
-AUTHY_API_KEY=d57d919d11e6b221c9bf6f7c882028f9
+# Find these credentials in the Twilio Console: https://www.twilio.com/console
+export TWILIO_ACCOUNT_SID="ACxxx"
+export TWILIO_AUTH_TOKEN="123xxx"
+
+
+# Create a Verify Service in the Console: https://www.twilio.com/console/verify/services
+export VERIFY_SERVICE_SID="VAxxx"

--- a/curl.sh
+++ b/curl.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
 
-# Send verification
-curl -i "https://api.authy.com/protected/json/sms/${AUTHY_ID}" \
-    -H "X-Authy-API-Key: ${AUTHY_API_KEY}"
+# phone number in E.164 format https://www.twilio.com/docs/glossary/what-e164
+PHONE_NUMBER="+15017122661"
 
-# Check verification
-curl -i "https://api.authy.com/protected/json/verify/${TOKEN}/${AUTHY_ID}" \
-    -H "X-Authy-API-Key: ${AUTHY_API_KEY}"
+curl -X POST https://verify.twilio.com/v2/Services/$VERIFY_SERVICE_SID/Verifications \
+    --data-urlencode "To=$PHONE_NUMBER" \
+    --data-urlencode "Channel=sms" \
+    -u $TWILIO_ACCOUNT_SID:$TWILIO_AUTH_TOKEN

--- a/curl.sh
+++ b/curl.sh
@@ -3,7 +3,14 @@
 # phone number in E.164 format https://www.twilio.com/docs/glossary/what-e164
 PHONE_NUMBER="+15017122661"
 
+# Send verification
 curl -X POST https://verify.twilio.com/v2/Services/$VERIFY_SERVICE_SID/Verifications \
     --data-urlencode "To=$PHONE_NUMBER" \
     --data-urlencode "Channel=sms" \
+    -u $TWILIO_ACCOUNT_SID:$TWILIO_AUTH_TOKEN
+
+# Check verification
+curl -X POST https://verify.twilio.com/v2/Services/$VERIFY_SERVICE_SID/VerificationCheck \
+    --data-urlencode "To=$PHONE_NUMBER" \
+    --data-urlencode "Code=1234" \
     -u $TWILIO_ACCOUNT_SID:$TWILIO_AUTH_TOKEN


### PR DESCRIPTION
Here's what you'll need to change:

1. Instead of the Authy API URL, use the [Twilio Verify base URL](https://www.twilio.com/docs/verify/api).
2. Instead of an Authy API Key, you'll need your [Twilio Account SID and Auth Token](https://www.twilio.com/console). 
3. You'll also need to create a [Verify Service and grab the SID](https://www.twilio.com/console/verify/services).
4. Finally, instead of the Authy ID, use the [phone number in E.164 format](https://www.twilio.com/docs/glossary/what-e164).

[Docs](https://www.twilio.com/docs/verify/api/verification?code-sample=code-start-a-verification-with-sms&code-language=curl&code-sdk-version=json)

To send a verification for the voice channel, all you need to do is change the `Channel` to `call`.