### PR TITLE
[NODE.JS] Migrate from Authy to Verify for SMS 2FA

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,7 @@
-AUTHY_ID=123456
-AUTHY_API_KEY=d57d919d11e6b221c9bf6f7c882028f9
+# Find these credentials in the Twilio Console: https://www.twilio.com/console
+export TWILIO_ACCOUNT_SID="ACxxx"
+export TWILIO_AUTH_TOKEN="123xxx"
+
+
+# Create a Verify Service in the Console: https://www.twilio.com/console/verify/services
+export VERIFY_SERVICE_SID="VAxxx"

--- a/node.js
+++ b/node.js
@@ -1,17 +1,27 @@
-// Download the helper library from https://github.com/evilpacket/node-authy
+// Download the helper library from https://www.twilio.com/docs/node/install
+// Your Account Sid and Auth Token from twilio.com/console
+// and set the environment variables. See http://twil.io/secure
+const accountSid = process.env.TWILIO_ACCOUNT_SID;
+const authToken = process.env.TWILIO_AUTH_TOKEN;
+const client = require("twilio")(accountSid, authToken);
 
-// Your API key from twilio.com/console/authy/applications
-// DANGER! This is insecure. See http://twil.io/secure
-var authy = require("authy")(process.env.AUTHY_API_KEY);
+// Create a Verify Service in the Console: https://www.twilio.com/console/verify/services
+const verifyServiceSid = process.env.VERIFY_SERVICE_SID;
+
+// Use this instead of the Authy ID.
+// Must be in E.164 format: https://www.twilio.com/docs/glossary/what-e164
+const toNumber = "+15017122661";
 
 function send() {
-  authy.request_sms(process.env.AUTHY_ID, function (err, res) {
-    console.log(res.message);
-  });
+  client.verify
+    .services(verifyServiceSid)
+    .verifications.create({ to: toNumber, channel: "sms" })
+    .then((verification) => console.log(verification.sid));
 }
 
 function check(token) {
-  authy.verify(process.env.AUTHY_ID, (token = token), function (err, res) {
-    console.log(res.message);
-  });
+  client.verify
+    .services(verifyServiceSid)
+    .verificationChecks.create({ to: toNumber, code: token })
+    .then((verification_check) => console.log(verification_check.status));
 }


### PR DESCRIPTION
Here's what you'll need to change:

1. Instead of the Authy Node library, use the [Twilio Node library](https://www.twilio.com/docs/node/install).
2. Instead of Authy API Keys, you'll need your [Twilio Account SID and Auth Token](https://www.twilio.com/console). 
3. You'll also need to create a [Verify Service and grab the SID](https://www.twilio.com/console/verify/services).
4. Finally, instead of the Authy ID, use the [phone number in E.164 format](https://www.twilio.com/docs/glossary/what-e164).

[Docs](https://www.twilio.com/docs/verify/api/verification?code-sample=code-start-a-verification-with-sms&code-language=Node.js&code-sdk-version=3.x)

To send a verification for the voice channel, all you need to do is change the `channel` to `call`.