### PR TITLE
[C# / .NET] Migrate from Authy to Verify for SMS 2FA

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,7 @@
-AUTHY_ID=123456
-AUTHY_API_KEY=d57d919d11e6b221c9bf6f7c882028f9
+# Find these credentials in the Twilio Console: https://www.twilio.com/console
+export TWILIO_ACCOUNT_SID="ACxxx"
+export TWILIO_AUTH_TOKEN="123xxx"
+
+
+# Create a Verify Service in the Console: https://www.twilio.com/console/verify/services
+export VERIFY_SERVICE_SID="VAxxx"

--- a/dotnet.cs
+++ b/dotnet.cs
@@ -1,41 +1,42 @@
 using System;
-using System.Net.Http;
-using System.Collections.Generic;
+using Twilio;
+using Twilio.Rest.Verify.V2.Service;
 
 
 class Program
 {
     static void Main(string[] args)
     {
-        // Your API key from twilio.com/console/authy/applications
-        // DANGER! This is insecure. See http://twil.io/secure
-        var AuthyAPIKey = "your_api_key";
-        var AuthyId = "user's authy id";
+        // Find your Account Sid and Token at twilio.com/console
+        // and set the environment variables. See http://twil.io/secure
+        string accountSid = Environment.GetEnvironmentVariable("TWILIO_ACCOUNT_SID");
+        string authToken = Environment.GetEnvironmentVariable("TWILIO_AUTH_TOKEN");
+
+        // Create a Verify Service in the Console: https://www.twilio.com/console/verify/services
+        string verifyServiceSid = Environment.GetEnvironmentVariable("VERIFY_SERVICE_SID");
+
+        // Use this instead of the Authy ID.
+        // Must be in E.164 format: https://www.twilio.com/docs/glossary/what-e164
+        string toNumber = "+15017122661";
+
+        TwilioClient.Init(accountSid, authToken);
 
         // Send verification
-        using (var client = new HttpClient())
-        {
-            client.DefaultRequestHeaders.Add("X-Authy-API-Key", AuthyAPIKey);
+        var verification = VerificationResource.Create(
+            to: toNumber,
+            channel: "sms",
+            pathServiceSid: verifyServiceSid
+        );
 
-            HttpResponseMessage response = client.GetAsync(
-                $"https://api.authy.com/protected/json/sms/{AuthyId}").Result;
-
-            HttpContent responseContent = response.Content;
-            Console.WriteLine(responseContent.ReadAsStringAsync().Result);
-        }
+        Console.WriteLine(verification.Sid);
 
         // Check verification
-        using (var client = new HttpClient())
-        {
-            client.DefaultRequestHeaders.Add("X-Authy-API-Key", AuthyAPIKey);
+        var verificationCheck = VerificationCheckResource.Create(
+            to: toNumber,
+            code: "1234",
+            pathServiceSid: verifyServiceSid
+        );
 
-            var token = 1234567;
-
-            HttpResponseMessage response = client.GetAsync(
-                $"https://api.authy.com/protected/json/verify/{token}/{AuthyId}").Result;
-
-            HttpContent responseContent = response.Content;
-            Console.WriteLine(responseContent.ReadAsStringAsync().Result);
-        }
+        Console.WriteLine(verificationCheck.Status);
     }
 }


### PR DESCRIPTION
Here's what you'll need to change:

1. There is no Authy library for C#/.NET, you can now use the [Twilio C# / .NET library](twilio.com/docs/csharp/install).
2. Instead of Authy API Keys, you'll need your [Twilio Account SID and Auth Token](https://www.twilio.com/console). 
3. You'll also need to create a [Verify Service and grab the SID](https://www.twilio.com/console/verify/services).
4. Finally, instead of the Authy ID, use the [phone number in E.164 format](https://www.twilio.com/docs/glossary/what-e164).

[Docs](https://www.twilio.com/docs/verify/api/verification?code-sample=code-start-a-verification-with-sms&code-language=C%23&code-sdk-version=5.x)

To send a verification for the voice channel, all you need to do is change the `channel` to `call`.